### PR TITLE
decoded the returning bytes object of get_token(user) in order to use…

### DIFF
--- a/django/api/schema.py
+++ b/django/api/schema.py
@@ -42,7 +42,7 @@ class CreateUser(graphene.Mutation):
         user.save()
 
         profile_obj = profile.objects.get(user=user.id)        
-        token = get_token(user)
+        token = get_token(user).decode('utf-8')
         refresh_token = create_refresh_token(user)
         
         return CreateUser(user=user, profile=profile_obj, token=token, refresh_token=refresh_token)


### PR DESCRIPTION
the token generated by the function graphql_jwt.shortcuts.get_token is returning a bytes object and the createuser mutation is raising an error
![image](https://user-images.githubusercontent.com/12750615/126091332-4b75acf1-7d8a-4d54-ba04-aaeb4c094c28.png)
The solution is decode the bytes object like this: get_token(user).decode('utf-8')